### PR TITLE
Fix the multiple lookup relationship on Mapping process.

### DIFF
--- a/src/classes/Mapper.cls
+++ b/src/classes/Mapper.cls
@@ -952,8 +952,7 @@ public class Mapper extends Func {
                 return nextPath.isEmpty() ? next : getObject(next, nextPath);
             }
             else if(data instanceof SObject) {
-                SObject so = (SObject)data;
-                Object next = so.get(key);
+                Object next = new DTO(data).getObject(key);
                 List<String> nextPath = R.of(path).drop(1).toStringList();
                 return nextPath.isEmpty() ? next : getObject(next, nextPath);
             }


### PR DESCRIPTION
Using `SObject.get` is limited to non lookup fields. When the mapped key is more than 3 levels and the mapped object is an SObject, the code may break. This PR fixes the issue.